### PR TITLE
Support nd labels

### DIFF
--- a/src/napari_omero/widgets/ROIs.py
+++ b/src/napari_omero/widgets/ROIs.py
@@ -7,6 +7,7 @@ from napari.layers import Labels
 import numpy as np
 import pyperclip
 from napari.viewer import Viewer
+from napari.utils import progress
 from omero_rois import mask_from_binary_image
 from qtpy.QtWidgets import (
     QComboBox,

--- a/src/napari_omero/widgets/ROIs.py
+++ b/src/napari_omero/widgets/ROIs.py
@@ -73,8 +73,8 @@ class ROIWidget(QWidget):
         self.viewer.layers.selection.events.changed.connect(self._on_layer_selected)
 
         # Key bindings
-        self.viewer.bind_key("Control-Shift-c", self._on_copy_metadata)
-        self.viewer.bind_key("Control-Shift-v", self._on_paste_metadata)
+        self.viewer.bind_key("Control-c", self._on_copy_metadata)
+        self.viewer.bind_key("Control-v", self._on_paste_metadata)
 
     @property
     def selected_layer(self):
@@ -104,7 +104,7 @@ class ROIWidget(QWidget):
     def _on_link_layers(self):
         target_layer = self.viewer.layers[self.target_link_dropdown.currentText()]
 
-        if type(target_layer) not in self.supported_layers:
+        if not any([isinstance(target_layer, l) for l in self.supported_layers]):
             warnings.warn("Target layer type currently not supported.", stacklevel=2)
             return
 
@@ -116,8 +116,7 @@ class ROIWidget(QWidget):
         target_layer.metadata["omero"] = self.selected_layer.metadata["omero"]
         self.status_label.setText(f"Metadata pasted to {target_layer.name}")
 
-    @Viewer.bind_key("Control-Shift-c", overwrite=True)
-    def _on_copy_metadata(self, viewer):
+    def _on_copy_metadata(self, viewer = None):
         """Create a new shapes layer in the viewer and link to the selected layer."""
         # check if 'omero' field is in metadata
         if "omero" not in self.selected_layer.metadata:
@@ -130,10 +129,9 @@ class ROIWidget(QWidget):
 
         self.status_label.setText(f"Metadata copied from {self.selected_layer.name}")
 
-    @Viewer.bind_key("Control-Shift-v", overwrite=True)
-    def _on_paste_metadata(self, viewer):
+    def _on_paste_metadata(self, viewer: "napari.viewer.Viewer"=None):
         """Create a new labels layer in the viewer and link to the selected layer."""
-        target_layer = self.viewer.layers[self.target_link_dropdown.currentText()]
+        target_layer = viewer.layers[self.target_link_dropdown.currentText()]
 
         # paste from clipboard
         metadata_json = pyperclip.paste()


### PR DESCRIPTION
This pull request includes several improvements and bug fixes to the `src/napari_omero/widgets/ROIs.py` file. The most important changes involve updating imports, modifying key bindings, and enhancing the ROI upload functionality.

### Import Updates:
* Moved `napari.layers.Labels` import to follow `numpy` and `pyperclip` imports. Added `napari.utils.progress` import.

### Key Binding Modifications:
* Changed key bindings for copying and pasting metadata from "Control-Shift-c/v" to "Control-c/v" in `setup_widget` method.

### Method Signature Updates:
* Updated `__init__` method to use `Viewer` directly instead of `"napari.viewer.Viewer"`.
* Removed `@Viewer.bind_key` decorators from `_on_copy_metadata` and `_on_paste_metadata` methods and modified their signatures to accept an optional `viewer` parameter. [[1]](diffhunk://#diff-58f9550331e4d57ce49c85b554a5ea6a2f3a902154d3f61dc795aaeca26fc6a5L119-R119) [[2]](diffhunk://#diff-58f9550331e4d57ce49c85b554a5ea6a2f3a902154d3f61dc795aaeca26fc6a5L133-R134)

### ROI Upload Enhancements:
* Expanded `labels_data` to 4D if necessary and optimized ROI creation by pre-allocating ROI objects. Added functionality to assign random colors to labels and used `napari.utils.progress` for progress tracking during ROI upload.