### PR TITLE
Simplify the copy/paste to not use pyperclip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ classifiers = [
 dependencies = [
     "napari>=0.4.13",
     "omero-py",
-    "pyperclip",
     "omero-rois",
     "omero-marshal",
     # these come with napari ...


### PR DESCRIPTION
This is totally optional, but it does away with the dependency that isn't really being leveraged.
Instead of doing the serialization to JSON and then literal copy/paste with clipboard, this just stored the dict in an instance variable, that you already had but didn't use.
